### PR TITLE
Release v0.1.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,26 @@ env:
 
 jobs:
   check:
-    name: Compile and Test
-    runs-on: ubuntu-latest
+    name: Compile and Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: ${{ env.MSRV }}
           override: true
+      - name: Install Nextest
+        uses: taiki-e/install-action@nextest
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
       - name: Type Checking
         uses: actions-rs/cargo@v1
         with:
@@ -37,8 +45,8 @@ jobs:
       - name: Test
         uses: actions-rs/cargo@v1
         with:
-          command: test
-          args: --workspace --verbose --locked
+          command: nextest
+          args: run --workspace --verbose --locked
 
   lints:
     name: Linting and Formatting
@@ -101,7 +109,9 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           jobs: |
-            Compile and Test
+            Compile and Test (ubuntu-latest)
+            Compile and Test (macos-latest)
+            Compile and Test (windows-latest)
           message: |
             Make sure you keep an eye on build times!
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,18 @@ jobs:
           folder: target/doc
           single-commit: true
 
+  workflow-times:
+    name: Workflow Timings
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - name: Time Reporter
+        uses: Michael-F-Bryan/workflow-timer@v0.2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          jobs: |
+            Compile and Test
+          message: |
+            Make sure you keep an eye on build times!
+
+            The goal is to keep CI times under 5 minutes so developers can maintain a fast edit-compile-test cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ change, where applicable.
 
 ## [Unreleased] - ReleaseDate
 
+## [0.1.2] - 2023-06-06
+
 ### Fixed
 
 - When slicing a mmapped buffer, the resulting offsets would be relative to the
@@ -32,6 +34,7 @@ change, where applicable.
   (`bytes::Bytes`) or a mmapped buffer (`memmap2::Mmap`)
 
 <!-- next-url -->
-[Unreleased]: https://github.com/wasmerio/shared-buffer/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/wasmerio/shared-buffer/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/wasmerio/shared-buffer/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/wasmerio/shared-buffer/compare/v0.1.0..v0.1.1
 [0.1.0]: https://github.com/wasmerio/shared-buffer/compare/6c299238..v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "shared-buffer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/wasmerio/shared-buffer.git"
 rust-version = "1.64.0"
-version = "0.1.1"
+version = "0.1.2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This releases `shared-buffer v0.1.2` so the `webc` crate can use the fix from #1 in https://github.com/wasmerio/pirita/pull/114.