### PR TITLE
Allow turning an OwnedBuffer into a `Vec<u8>`

### DIFF
--- a/src/owned.rs
+++ b/src/owned.rs
@@ -261,6 +261,12 @@ impl From<&Vec<u8>> for OwnedBuffer {
     }
 }
 
+impl From<OwnedBuffer> for Vec<u8> {
+    fn from(value: OwnedBuffer) -> Self {
+        value.to_vec()
+    }
+}
+
 impl From<Repr> for OwnedBuffer {
     fn from(repr: Repr) -> Self {
         OwnedBuffer { repr }


### PR DESCRIPTION
I accidentally forgot this impl when extracting `webc::compat::SharedBytes` into its own crate and now it's breaking a `cargo install --path .` for the `wasmer` CLI.